### PR TITLE
Fixes `mix parser.import` from umbrella root

### DIFF
--- a/apps/parser/config/config.exs
+++ b/apps/parser/config/config.exs
@@ -2,6 +2,8 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :parser, ecto_repos: []
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/apps/parser/lib/parser/esm_file.ex
+++ b/apps/parser/lib/parser/esm_file.ex
@@ -9,7 +9,7 @@ defmodule Parser.EsmFile do
   import VariableSizes
   alias Parser.EsmFormatter
 
-  @default_file "data/Morrowind.esm"
+  @source_file Application.app_dir(:parser, "priv/Morrowind.esm")
 
   @doc """
   Creates a stream of data parsed from the named ESM file.
@@ -22,7 +22,7 @@ defmodule Parser.EsmFile do
       [{:book, %{...}}, {:weapon, %{...}}, ...]
   """
   @spec stream(filename :: String.t()) :: %Stream{}
-  def stream(filename \\ @default_file) do
+  def stream(filename \\ @source_file) do
     Stream.resource(
       fn -> File.open!(filename, [:binary]) end,
       fn(file) -> next_record(file) end,


### PR DESCRIPTION
Also fixes Ecto repo warnings when running Ecto tasks from the root of the umbrella emitted by the `parser` app